### PR TITLE
Add EquatorialCoordinate class for celestial coordinate system

### DIFF
--- a/cosmoscore-common/src/main/java/com/cosmoscore/common/coordinate/EquatorialCoordinate.java
+++ b/cosmoscore-common/src/main/java/com/cosmoscore/common/coordinate/EquatorialCoordinate.java
@@ -1,0 +1,47 @@
+package com.cosmoscore.common.coordinate;
+
+/**
+ * Represents a position in the equatorial coordinate system.
+ * This system uses right ascension (RA) and declination (Dec) to specify positions on the celestial sphere.
+ */
+public record EquatorialCoordinate(double rightAscension, double declination) {
+
+	/**
+	 * Creates a new equatorial coordinate with the given right ascension and declination.
+	 *
+	 * @param rightAscension right ascension in degrees (0 to 360)
+	 * @param declination declination in degrees (-90 to +90)
+	 * @throws IllegalArgumentException if the coordinates are outside their valid ranges
+	 */
+	public EquatorialCoordinate {
+		validateRightAscension(rightAscension);
+		validateDeclination(declination);
+	}
+
+	private void validateRightAscension(double ra) {
+		if (ra < 0 || ra > 360) {
+			throw new IllegalArgumentException("Right ascension must be between 0 and 360 degrees");
+		}
+	}
+
+	private void validateDeclination(double dec) {
+		if (dec < -90 || dec > 90) {
+			throw new IllegalArgumentException("Declination must be between -90 and +90 degrees");
+		}
+	}
+
+	/**
+	 * Converts right ascension from degrees to hours.
+	 * In astronomy, right ascension is traditionally measured in hours (0 to 24).
+	 *
+	 * @return right ascension in hours
+	 */
+	public double rightAscensionHours() {
+		return rightAscension / 15.0;
+	}
+
+	@Override
+	public String toString() {
+		return String.format("RA: %.2f°, Dec: %.2f°", rightAscension, declination);
+	}
+}

--- a/cosmoscore-common/src/main/java/com/cosmoscore/common/coordinate/EquatorialCoordinate.java
+++ b/cosmoscore-common/src/main/java/com/cosmoscore/common/coordinate/EquatorialCoordinate.java
@@ -1,38 +1,29 @@
 package com.cosmoscore.common.coordinate;
 
 /**
- * Represents a position in the equatorial coordinate system.
- * This system uses right ascension (RA) and declination (Dec) to specify positions on the celestial sphere.
+ * Represents a point on the celestial sphere using the equatorial coordinate system.
+ * This system uses right ascension (RA) and declination (Dec) to specify positions.
  */
 public record EquatorialCoordinate(double rightAscension, double declination) {
 
 	/**
-	 * Creates a new equatorial coordinate with the given right ascension and declination.
+	 * Creates an equatorial coordinate with validation.
 	 *
 	 * @param rightAscension right ascension in degrees (0 to 360)
 	 * @param declination declination in degrees (-90 to +90)
-	 * @throws IllegalArgumentException if the coordinates are outside their valid ranges
+	 * @throws IllegalArgumentException if coordinates are outside valid ranges
 	 */
 	public EquatorialCoordinate {
-		validateRightAscension(rightAscension);
-		validateDeclination(declination);
-	}
-
-	private void validateRightAscension(double ra) {
-		if (ra < 0 || ra > 360) {
+		if (rightAscension < 0 || rightAscension >= 360) {
 			throw new IllegalArgumentException("Right ascension must be between 0 and 360 degrees");
 		}
-	}
-
-	private void validateDeclination(double dec) {
-		if (dec < -90 || dec > 90) {
+		if (declination < -90 || declination > 90) {
 			throw new IllegalArgumentException("Declination must be between -90 and +90 degrees");
 		}
 	}
 
 	/**
-	 * Converts right ascension from degrees to hours.
-	 * In astronomy, right ascension is traditionally measured in hours (0 to 24).
+	 * Returns the right ascension in hours (0 to 24).
 	 *
 	 * @return right ascension in hours
 	 */
@@ -40,8 +31,106 @@ public record EquatorialCoordinate(double rightAscension, double declination) {
 		return rightAscension / 15.0;
 	}
 
-	@Override
-	public String toString() {
-		return String.format("RA: %.2f°, Dec: %.2f°", rightAscension, declination);
+	/**
+	 * Returns the hour component of the right ascension.
+	 *
+	 * @return hours (0-23)
+	 */
+	public int rightAscensionHourPart() {
+		return (int) (rightAscension / 15.0);
+	}
+
+	/**
+	 * Returns the minute component of the right ascension.
+	 *
+	 * @return minutes (0-59)
+	 */
+	public int rightAscensionMinutePart() {
+		double hours = rightAscension / 15.0;
+		return (int) ((hours - rightAscensionHourPart()) * 60);
+	}
+
+	/**
+	 * Returns the second component of the right ascension.
+	 *
+	 * @return seconds (0-59.99)
+	 */
+	public double rightAscensionSecondPart() {
+		double hours = rightAscension / 15.0;
+		double minutes = (hours - rightAscensionHourPart()) * 60;
+		return (minutes - rightAscensionMinutePart()) * 60;
+	}
+
+	/**
+	 * Returns the degree component of the declination.
+	 *
+	 * @return degrees (-90 to +90)
+	 */
+	public int declinationDegreePart() {
+		return (int) declination;
+	}
+
+	/**
+	 * Returns the arcminute component of the declination.
+	 *
+	 * @return arcminutes (0-59)
+	 */
+	public int declinationArcminutePart() {
+		double absDecDegrees = Math.abs(declination);
+		return (int) ((absDecDegrees - Math.abs(declinationDegreePart())) * 60);
+	}
+
+	/**
+	 * Returns the arcsecond component of the declination.
+	 *
+	 * @return arcseconds (0-59.99)
+	 */
+	public double declinationArcsecondPart() {
+		double absDecDegrees = Math.abs(declination);
+		double arcminutes = (absDecDegrees - Math.abs(declinationDegreePart())) * 60;
+		return (arcminutes - declinationArcminutePart()) * 60;
+	}
+
+	/**
+	 * Calculates the angular separation between this coordinate and another coordinate.
+	 * Uses the great circle distance formula.
+	 *
+	 * @param other the other coordinate
+	 * @return angular separation in degrees
+	 */
+	public double angularSeparation(EquatorialCoordinate other) {
+		double ra1 = Math.toRadians(this.rightAscension);
+		double ra2 = Math.toRadians(other.rightAscension);
+		double dec1 = Math.toRadians(this.declination);
+		double dec2 = Math.toRadians(other.declination);
+
+		double cosAngle = Math.sin(dec1) * Math.sin(dec2) +
+			Math.cos(dec1) * Math.cos(dec2) * Math.cos(ra1 - ra2);
+
+		return Math.toDegrees(Math.acos(Math.min(1.0, Math.max(-1.0, cosAngle))));
+	}
+
+	/**
+	 * Formats the right ascension in hours, minutes, and seconds.
+	 *
+	 * @return formatted string in the format "XXh YYm ZZ.ZZs"
+	 */
+	public String formatRightAscension() {
+		return String.format("%dh %02dm %05.2fs",
+			rightAscensionHourPart(),
+			rightAscensionMinutePart(),
+			rightAscensionSecondPart());
+	}
+
+	/**
+	 * Formats the declination in degrees, arcminutes, and arcseconds.
+	 *
+	 * @return formatted string in the format "±XX° YY' ZZ.ZZ""
+	 */
+	public String formatDeclination() {
+		return String.format("%+d° %02d' %05.2f\"",
+			declinationDegreePart(),
+			declinationArcminutePart(),
+			declinationArcsecondPart());
 	}
 }

--- a/cosmoscore-common/src/test/java/com/cosmoscore/common/coordinate/EquatorialCoordinateTest.java
+++ b/cosmoscore-common/src/test/java/com/cosmoscore/common/coordinate/EquatorialCoordinateTest.java
@@ -1,0 +1,79 @@
+package com.cosmoscore.common.coordinate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.withPrecision;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("EquatorialCoordinate class")
+class EquatorialCoordinateTest {
+
+	private static final double PRECISION = 1e-10;
+
+	@Nested
+	@DisplayName("creation")
+	class Creation {
+		@Test
+		@DisplayName("creates with right ascension and declination in degrees")
+		void createWithDegrees() {
+			double rightAscension = 123.45;
+			double declination = 67.89;
+
+			EquatorialCoordinate actual = new EquatorialCoordinate(rightAscension, declination);
+
+			assertThat(actual.rightAscension()).isEqualTo(rightAscension, withPrecision(PRECISION));
+			assertThat(actual.declination()).isEqualTo(declination, withPrecision(PRECISION));
+		}
+
+		@Test
+		@DisplayName("validates right ascension range")
+		void validateRightAscension() {
+			assertThatThrownBy(() -> new EquatorialCoordinate(-1.0, 0))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("Right ascension must be between 0 and 360 degrees");
+
+			assertThatThrownBy(() -> new EquatorialCoordinate(360.1, 0))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("Right ascension must be between 0 and 360 degrees");
+		}
+
+		@Test
+		@DisplayName("validates declination range")
+		void validateDeclination() {
+			assertThatThrownBy(() -> new EquatorialCoordinate(0, -90.1))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("Declination must be between -90 and +90 degrees");
+
+			assertThatThrownBy(() -> new EquatorialCoordinate(0, 90.1))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("Declination must be between -90 and +90 degrees");
+		}
+	}
+
+	@Nested
+	@DisplayName("conversions")
+	class Conversions {
+		@Test
+		@DisplayName("converts between degrees and hours for right ascension")
+		void convertRightAscension() {
+			double raDegrees = 180.0;
+
+			EquatorialCoordinate actual = new EquatorialCoordinate(raDegrees, 0);
+
+			assertThat(actual.rightAscensionHours()).isEqualTo(12.0, withPrecision(PRECISION));
+		}
+
+		@Test
+		@DisplayName("formats coordinates as string")
+		void formatAsString() {
+			EquatorialCoordinate coordinate = new EquatorialCoordinate(123.45, 67.89);
+
+			String formatted = coordinate.toString();
+
+			assertThat(formatted).contains("123.45").contains("67.89");
+		}
+	}
+}

--- a/cosmoscore-common/src/test/java/com/cosmoscore/common/coordinate/EquatorialCoordinateTest.java
+++ b/cosmoscore-common/src/test/java/com/cosmoscore/common/coordinate/EquatorialCoordinateTest.java
@@ -71,9 +71,80 @@ class EquatorialCoordinateTest {
 		void formatAsString() {
 			EquatorialCoordinate coordinate = new EquatorialCoordinate(123.45, 67.89);
 
-			String formatted = coordinate.toString();
+			String actual = coordinate.toString();
 
-			assertThat(formatted).contains("123.45").contains("67.89");
+			assertThat(actual).contains("123.45").contains("67.89");
+		}
+	}
+
+	@Nested
+	@DisplayName("time unit conversions")
+	class TimeUnitConversions {
+		@Test
+		@DisplayName("converts right ascension to hours, minutes, and seconds")
+		void convertRightAscensionToHMS() {
+			EquatorialCoordinate coordinate = new EquatorialCoordinate(152.75, 0);
+
+			int hours = coordinate.rightAscensionHourPart();
+			int minutes = coordinate.rightAscensionMinutePart();
+			double seconds = coordinate.rightAscensionSecondPart();
+
+			assertThat(hours).isEqualTo(10);
+			assertThat(minutes).isEqualTo(11);
+			assertThat(seconds).isEqualTo(0.0, withPrecision(PRECISION));
+		}
+
+		@Test
+		@DisplayName("converts declination to degrees, arcminutes, and arcseconds")
+		void convertDeclinationToDMS() {
+			EquatorialCoordinate coordinate = new EquatorialCoordinate(0, 42.5);
+
+			int degrees = coordinate.declinationDegreePart();
+			int arcminutes = coordinate.declinationArcminutePart();
+			double arcseconds = coordinate.declinationArcsecondPart();
+
+			assertThat(degrees).isEqualTo(42);
+			assertThat(arcminutes).isEqualTo(30);
+			assertThat(arcseconds).isEqualTo(0.0, withPrecision(PRECISION));
+		}
+	}
+
+	@Nested
+	@DisplayName("angle calculations")
+	class AngleCalculations {
+		@Test
+		@DisplayName("calculates angular separation between two coordinates")
+		void calculateAngularSeparation() {
+			EquatorialCoordinate coord1 = new EquatorialCoordinate(0, 0);
+			EquatorialCoordinate coord2 = new EquatorialCoordinate(0, 90);
+
+			double separation = coord1.angularSeparation(coord2);
+
+			assertThat(separation).isEqualTo(90.0, withPrecision(PRECISION));
+		}
+	}
+
+	@Nested
+	@DisplayName("formatting")
+	class Formatting {
+		@Test
+		@DisplayName("formats right ascension in HMS format")
+		void formatRightAscensionHMS() {
+			EquatorialCoordinate coordinate = new EquatorialCoordinate(152.75, 0);
+
+			String actual = coordinate.formatRightAscension();
+
+			assertThat(actual).isEqualTo("10h 11m 00.00s");
+		}
+
+		@Test
+		@DisplayName("formats declination in DMS format")
+		void formatDeclinationDMS() {
+			EquatorialCoordinate coordinate = new EquatorialCoordinate(0, 42.5);
+
+			String actual = coordinate.formatDeclination();
+
+			assertThat(actual).isEqualTo("+42° 30' 00.00\"");
 		}
 	}
 }


### PR DESCRIPTION
## Description
This PR adds the EquatorialCoordinate class to the cosmoscore-common module for representing positions on the celestial sphere.

## Features
### Core Coordinates
- Right Ascension (RA): 0° to 360°
- Declination (Dec): -90° to +90°

### Time and Angle Conversions
- RA conversion to hours (0-24h)
- RA parts (hours, minutes, seconds)
- Dec parts (degrees, arcminutes, arcseconds)

### Astronomical Calculations
- Angular separation between coordinates
- Standard coordinate formatting
- Input validation



## Technical Details
- Implemented as an immutable record class
- Comprehensive test coverage
- Full Javadoc documentation
- Thread-safe design

## Example Usage
```java
// Create a coordinate
EquatorialCoordinate coord = new EquatorialCoordinate(180.0, 45.0);

// Get formatted strings
String ra = coord.formatRightAscension();  // "12h 00m 00.00s"
String dec = coord.formatDeclination();    // "+45° 00' 00.00""

// Calculate angular separation
double separation = coord.angularSeparation(otherCoord);
```