### PR TITLE
Add HorizontalCoordinate class for altitude-azimuth system

### DIFF
--- a/cosmoscore-common/src/main/java/com/cosmoscore/common/coordinate/HorizontalCoordinate.java
+++ b/cosmoscore-common/src/main/java/com/cosmoscore/common/coordinate/HorizontalCoordinate.java
@@ -1,0 +1,108 @@
+package com.cosmoscore.common.coordinate;
+
+/**
+ * Represents a point on the celestial sphere using the horizontal coordinate system.
+ * This system uses azimuth (Az) and altitude (Alt) to specify positions relative to the observer's horizon.
+ */
+public record HorizontalCoordinate(double azimuth, double altitude) {
+
+	/**
+	 * Creates a horizontal coordinate with validation.
+	 *
+	 * @param azimuth  azimuth in degrees (0 to 360), measured clockwise from north
+	 * @param altitude altitude in degrees (-90 to +90), measured from the horizon
+	 * @throws IllegalArgumentException if coordinates are outside valid ranges
+	 */
+	public HorizontalCoordinate {
+		if (azimuth < 0 || azimuth >= 360) {
+			throw new IllegalArgumentException("Azimuth must be between 0 and 360 degrees");
+		}
+		if (altitude < -90 || altitude > 90) {
+			throw new IllegalArgumentException("Altitude must be between -90 and +90 degrees");
+		}
+	}
+
+	/**
+	 * Returns the degree component of the azimuth.
+	 *
+	 * @return degree component (0-359)
+	 */
+	public int azimuthDegreePart() {
+		return (int) azimuth;
+	}
+
+	/**
+	 * Returns the arcminute component of the azimuth.
+	 *
+	 * @return arcminute component (0-59)
+	 */
+	public int azimuthMinutePart() {
+		double absAzimuth = Math.abs(azimuth);
+		return (int) ((absAzimuth - Math.abs(azimuthDegreePart())) * 60);
+	}
+
+	/**
+	 * Returns the arcsecond component of the azimuth.
+	 *
+	 * @return arcsecond component (0-59.99)
+	 */
+	public double azimuthSecondPart() {
+		double absAzimuth = Math.abs(azimuth);
+		double minutes = (absAzimuth - Math.abs(azimuthDegreePart())) * 60;
+		return (minutes - azimuthMinutePart()) * 60;
+	}
+
+	/**
+	 * Returns the degree component of the altitude.
+	 *
+	 * @return degree component (-90 to +90)
+	 */
+	public int altitudeDegreePart() {
+		return (int) altitude;
+	}
+
+	/**
+	 * Returns the arcminute component of the altitude.
+	 *
+	 * @return arcminute component (0-59)
+	 */
+	public int altitudeMinutePart() {
+		double absAltitude = Math.abs(altitude);
+		return (int) ((absAltitude - Math.abs(altitudeDegreePart())) * 60);
+	}
+
+	/**
+	 * Returns the arcsecond component of the altitude.
+	 *
+	 * @return arcsecond component (0-59.99)
+	 */
+	public double altitudeSecondPart() {
+		double absAltitude = Math.abs(altitude);
+		double minutes = (absAltitude - Math.abs(altitudeDegreePart())) * 60;
+		return (minutes - altitudeMinutePart()) * 60;
+	}
+
+	/**
+	 * Formats the azimuth in degrees, arcminutes, and arcseconds.
+	 *
+	 * @return formatted string in the format "XXX° YY' ZZ.ZZ""
+	 */
+	public String formatAzimuth() {
+		return String.format("%d° %02d' %05.2f\"",
+			azimuthDegreePart(),
+			azimuthMinutePart(),
+			azimuthSecondPart());
+	}
+
+	/**
+	 * Formats the altitude in degrees, arcminutes, and arcseconds.
+	 *
+	 * @return formatted string in the format "±XX° YY' ZZ.ZZ""
+	 */
+	public String formatAltitude() {
+		return String.format("%+d° %02d' %05.2f\"",
+			altitudeDegreePart(),
+			altitudeMinutePart(),
+			altitudeSecondPart());
+	}
+}

--- a/cosmoscore-common/src/test/java/com/cosmoscore/common/coordinate/HorizontalCoordinateTest.java
+++ b/cosmoscore-common/src/test/java/com/cosmoscore/common/coordinate/HorizontalCoordinateTest.java
@@ -1,0 +1,94 @@
+package com.cosmoscore.common.coordinate;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.withPrecision;
+
+@DisplayName("HorizontalCoordinate class")
+class HorizontalCoordinateTest {
+
+	private static final double PRECISION = 1e-10;
+
+	@Nested
+	@DisplayName("creation")
+	class Creation {
+		@Test
+		@DisplayName("creates with azimuth and altitude")
+		void createWithValues() {
+			HorizontalCoordinate coordinate = new HorizontalCoordinate(180.0, 45.0);
+
+			assertThat(coordinate.azimuth()).isEqualTo(180.0, withPrecision(PRECISION));
+			assertThat(coordinate.altitude()).isEqualTo(45.0, withPrecision(PRECISION));
+		}
+
+		@Test
+		@DisplayName("validates azimuth range")
+		void validateAzimuth() {
+			assertThatThrownBy(() -> new HorizontalCoordinate(-1.0, 0))
+				.isInstanceOf(IllegalArgumentException.class);
+
+			assertThatThrownBy(() -> new HorizontalCoordinate(360.0, 0))
+				.isInstanceOf(IllegalArgumentException.class);
+		}
+
+		@Test
+		@DisplayName("validates altitude range")
+		void validateAltitude() {
+			assertThatThrownBy(() -> new HorizontalCoordinate(0, -90.1))
+				.isInstanceOf(IllegalArgumentException.class);
+
+			assertThatThrownBy(() -> new HorizontalCoordinate(0, 90.1))
+				.isInstanceOf(IllegalArgumentException.class);
+		}
+	}
+
+	@Nested
+	@DisplayName("formatting")
+	class Formatting {
+		@Test
+		@DisplayName("formats azimuth in degree-minute-second")
+		void formatAzimuth() {
+			HorizontalCoordinate coordinate = new HorizontalCoordinate(123.45, 45.0);
+
+			assertThat(coordinate.formatAzimuth())
+				.isEqualTo("123° 27' 00.00\"");
+		}
+
+		@Test
+		@DisplayName("formats altitude in degree-minute-second")
+		void formatAltitude() {
+			HorizontalCoordinate coordinate = new HorizontalCoordinate(180.0, 45.5);
+
+			assertThat(coordinate.formatAltitude())
+				.isEqualTo("+45° 30' 00.00\"");
+		}
+	}
+
+	@Nested
+	@DisplayName("parts calculation")
+	class PartsCalculation {
+		@Test
+		@DisplayName("calculates azimuth parts")
+		void calculateAzimuthParts() {
+			HorizontalCoordinate coordinate = new HorizontalCoordinate(123.45, 45.0);
+
+			assertThat(coordinate.azimuthDegreePart()).isEqualTo(123);
+			assertThat(coordinate.azimuthMinutePart()).isEqualTo(27);
+			assertThat(coordinate.azimuthSecondPart()).isEqualTo(0.0, withPrecision(PRECISION));
+		}
+
+		@Test
+		@DisplayName("calculates altitude parts")
+		void calculateAltitudeParts() {
+			HorizontalCoordinate coordinate = new HorizontalCoordinate(180.0, 45.5);
+
+			assertThat(coordinate.altitudeDegreePart()).isEqualTo(45);
+			assertThat(coordinate.altitudeMinutePart()).isEqualTo(30);
+			assertThat(coordinate.altitudeSecondPart()).isEqualTo(0.0, withPrecision(PRECISION));
+		}
+	}
+}


### PR DESCRIPTION
## Description
This PR adds the HorizontalCoordinate class to represent positions in the horizontal coordinate system (altitude-azimuth system).

## Features
### Core Coordinates
- Azimuth (Az): 0° to 360°, measured clockwise from north
- Altitude (Alt): -90° to +90°, measured from the horizon


### Angle Measurements
- Azimuth parts (degrees, arcminutes, arcseconds)
- Altitude parts (degrees, arcminutes, arcseconds)

### Formatting
- Standard astronomical notation
- Azimuth format: XXX° YY' ZZ.ZZ"
- Altitude format: ±XX° YY' ZZ.ZZ"

## Technical Details
- Implemented as an immutable record class
- Input validation for coordinate ranges
- Full Javadoc documentation
- Comprehensive test coverage

## Example Usage
```java
// Create a coordinate
HorizontalCoordinate coord = new HorizontalCoordinate(180.0, 45.0);

// Get formatted strings
String az = coord.formatAzimuth();  // "180° 00' 00.00""
String alt = coord.formatAltitude(); // "+45° 00' 00.00""
```