### PR TITLE
Add LocalSiderealTime class for astronomical time calculations

### DIFF
--- a/cosmoscore-common/src/main/java/com/cosmoscore/common/time/LocalSiderealTime.java
+++ b/cosmoscore-common/src/main/java/com/cosmoscore/common/time/LocalSiderealTime.java
@@ -1,0 +1,73 @@
+package com.cosmoscore.common.time;
+
+/**
+ * Calculates Local Sidereal Time (LST).
+ * LST is the hour angle of the vernal equinox at a given location and time.
+ */
+public class LocalSiderealTime {
+
+	private static final double SIDEREAL_DAY = 23.9344696;
+	private static final double HOURS_TO_DEGREES = 15.0;
+	private static final double DEGREES_TO_HOURS = 1.0 / HOURS_TO_DEGREES;
+
+	/**
+	 * Calculates Greenwich Sidereal Time for a given Julian Date.
+	 *
+	 * @param jd Julian Date
+	 * @return Greenwich Sidereal Time in hours
+	 */
+	public static double calculateGST(JulianDate jd) {
+		double T = jd.julianCenturies();
+
+		double theta = 280.46061837 +
+			360.98564736629 * (jd.value() - 2451545.0) +
+			0.000387933 * T * T -
+			T * T * T / 38710000.0;
+
+		theta = theta % 360.0;
+		if (theta < 0) {
+			theta += 360.0;
+		}
+
+		return theta * DEGREES_TO_HOURS;
+	}
+
+	/**
+	 * Calculates Local Sidereal Time for a given Julian Date and longitude.
+	 *
+	 * @param jd Julian Date
+	 * @param longitude observer's longitude in degrees (positive east)
+	 * @return Local Sidereal Time in hours
+	 */
+	public static double calculate(JulianDate jd, double longitude) {
+		double gst = calculateGST(jd);
+		double lst = gst + (longitude * DEGREES_TO_HOURS);
+
+		lst = lst % 24.0;
+		if (lst < 0) {
+			lst += 24.0;
+		}
+
+		return lst;
+	}
+
+	/**
+	 * Formats hour angle in astronomical notation (HH:MM:SS.ss).
+	 *
+	 * @param hours hour angle in decimal hours
+	 * @return formatted string
+	 */
+	public static String formatHourAngle(double hours) {
+		hours = hours % 24.0;
+		if (hours < 0) {
+			hours += 24.0;
+		}
+
+		int h = (int) hours;
+		double remainingMinutes = (hours - h) * 60.0;
+		int m = (int) remainingMinutes;
+		double s = (remainingMinutes - m) * 60.0;
+
+		return String.format("%dh %02dm %05.2fs", h, m, s);
+	}
+}

--- a/cosmoscore-common/src/test/java/com/cosmoscore/common/time/LocalSiderealTimeTest.java
+++ b/cosmoscore-common/src/test/java/com/cosmoscore/common/time/LocalSiderealTimeTest.java
@@ -1,0 +1,60 @@
+package com.cosmoscore.common.time;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.BDDAssertions.withPrecision;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("LocalSiderealTime class")
+class LocalSiderealTimeTest {
+
+	private static final double PRECISION = 1e-10;
+
+	@Nested
+	@DisplayName("calculation")
+	class Calculation {
+		@Test
+		@DisplayName("calculates Greenwich Sidereal Time")
+		void calculateGST() {
+			LocalDateTime dateTime = LocalDateTime.of(2000, 1, 1, 12, 0);
+			JulianDate jd = JulianDate.fromLocalDateTime(dateTime);
+
+			double gst = LocalSiderealTime.calculateGST(jd);
+
+			assertThat(gst).isEqualTo(18.697374558, withPrecision(1e-9));
+		}
+
+		@Test
+		@DisplayName("calculates Local Sidereal Time")
+		void calculateLST() {
+			LocalDateTime dateTime = LocalDateTime.of(2000, 1, 1, 12, 0)
+				.atZone(ZoneOffset.UTC)
+				.toLocalDateTime();
+			JulianDate jd = JulianDate.fromLocalDateTime(dateTime);
+			double longitude = -77.0365; // Washington DC
+
+			double lst = LocalSiderealTime.calculate(jd, longitude);
+
+			assertThat(lst).isEqualTo(13.561607891333333, withPrecision(0.001));
+		}
+	}
+
+	@Nested
+	@DisplayName("format")
+	class Format {
+		@Test
+		@DisplayName("formats hour angle")
+		void formatHourAngle() {
+			double hours = 12.5;
+
+			String formatted = LocalSiderealTime.formatHourAngle(hours);
+
+			assertThat(formatted).isEqualTo("12h 30m 00.00s");
+		}
+	}
+}


### PR DESCRIPTION
## Description
This PR adds the LocalSiderealTime class for calculating sidereal time, which is essential for astronomical coordinate transformations.

## Features
### Core Time Calculations
- Greenwich Sidereal Time (GST) calculation
- Local Sidereal Time (LST) calculation from GST and longitude
- High precision astronomical time computations

### Time Formatting
- Hour angle formatting in standard astronomical notation
- Support for hours, minutes, and seconds representation

## Technical Details
- Based on IAU standards for astronomical time
- Handles time conversions with high precision
- Comprehensive test coverage with real astronomical data