### PR TITLE
Add toEquatorial conversion method to Observer class

### DIFF
--- a/cosmoscore-common/src/main/java/com/cosmoscore/common/coordinate/Observer.java
+++ b/cosmoscore-common/src/main/java/com/cosmoscore/common/coordinate/Observer.java
@@ -58,4 +58,29 @@ public record Observer(double latitude, double longitude) {
 
 		return new HorizontalCoordinate(azimuth, altitude);
 	}
+
+	public EquatorialCoordinate toEquatorial(HorizontalCoordinate horizontal, LocalDateTime observationTime) {
+		JulianDate jd = JulianDate.fromLocalDateTime(observationTime);
+		double lst = LocalSiderealTime.calculate(jd, longitude);
+
+		double azRad = Math.toRadians(horizontal.azimuth());
+		double altRad = Math.toRadians(horizontal.altitude());
+		double latRad = Math.toRadians(latitude);
+
+		double sinDec = Math.sin(altRad) * Math.sin(latRad) +
+			Math.cos(altRad) * Math.cos(latRad) * Math.cos(azRad);
+		double declination = Math.toDegrees(Math.asin(sinDec));
+
+		double cosH = (Math.sin(altRad) - Math.sin(latRad) * sinDec) /
+			(Math.cos(latRad) * Math.cos(Math.asin(sinDec)));
+		double sinH = -Math.sin(azRad) * Math.cos(altRad) / Math.cos(Math.asin(sinDec));
+		double ha = Math.toDegrees(Math.atan2(sinH, cosH));
+
+		double rightAscension = (lst * 15.0 - ha) % 360.0;
+		if (rightAscension < 0) {
+			rightAscension += 360.0;
+		}
+
+		return new EquatorialCoordinate(rightAscension, declination);
+	}
 }

--- a/cosmoscore-common/src/test/java/com/cosmoscore/common/coordinate/ObserverTest.java
+++ b/cosmoscore-common/src/test/java/com/cosmoscore/common/coordinate/ObserverTest.java
@@ -88,5 +88,23 @@ class ObserverTest {
 
 			assertThat(horizontal.altitude()).isCloseTo(-14.2108, offset(1.0));
 		}
+
+		@Test
+		@DisplayName("converts horizontal to equatorial coordinates")
+		void convertToEquatorial() {
+			Observer observer = new Observer(37.5665, 126.9780);
+			LocalDateTime observationTime = LocalDateTime.of(2025, 1, 1, 12, 0)
+				.atZone(ZoneOffset.UTC)
+				.toLocalDateTime();
+
+			HorizontalCoordinate horizontal = new HorizontalCoordinate(180.0, 45.0);
+
+			EquatorialCoordinate equatorial = observer.toEquatorial(horizontal, observationTime);
+
+			HorizontalCoordinate reconverted = observer.toHorizontal(equatorial, observationTime);
+
+			assertThat(reconverted.azimuth()).isCloseTo(horizontal.azimuth(), offset(0.01));
+			assertThat(reconverted.altitude()).isCloseTo(horizontal.altitude(), offset(0.01));
+		}
 	}
 }


### PR DESCRIPTION
## Description
This PR adds the toEquatorial conversion method to the Observer class, enabling transformation from horizontal to equatorial coordinates.

## Feature
- Adds toEquatorial method that converts horizontal coordinates (azimuth, altitude) to equatorial coordinates (right ascension, declination)
- Considers observer's position and observation time using Local Sidereal Time
- Implements standard astronomical conversion formulas using spherical trigonometry